### PR TITLE
Check for proxy prefix early, so RemoteAddr doesn't block Accept

### DIFF
--- a/protocol_test.go
+++ b/protocol_test.go
@@ -12,8 +12,8 @@ func TestPassthrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	pl := &Listener{l}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
 
 	go func() {
 		conn, err := net.Dial("tcp", pl.Addr().String())
@@ -58,8 +58,8 @@ func TestParse_ipv4(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	pl := &Listener{l}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
 
 	go func() {
 		conn, err := net.Dial("tcp", pl.Addr().String())
@@ -117,8 +117,8 @@ func TestParse_ipv6(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	pl := &Listener{l}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
 
 	go func() {
 		conn, err := net.Dial("tcp", pl.Addr().String())
@@ -176,8 +176,8 @@ func TestParse_BadHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	pl := &Listener{l}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
 
 	go func() {
 		conn, err := net.Dial("tcp", pl.Addr().String())


### PR DESCRIPTION
Check for proxy prefix early, so RemoteAddr doesn't block Accept.

And idiomatic cleanups because I couldn't help myself.

I don't use this and don't care whether you accept this pull request. Feel free to close it outright if you'd like.

I created it as part of discussion for https://go-review.googlesource.com/#/c/15832/
