### PR TITLE
Error on invalid proxyprotocol prefix

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -104,6 +104,7 @@ func (p *Conn) RemoteAddr() net.Addr {
 	p.once.Do(func() {
 		if err := p.checkPrefix(); err != nil && err != io.EOF {
 			log.Printf("[ERR] Failed to read proxy prefix: %v", err)
+			p.Close()
 		}
 	})
 	if p.srcAddr != nil {

--- a/protocol.go
+++ b/protocol.go
@@ -134,7 +134,7 @@ func (p *Conn) checkPrefix() error {
 
 		// Check for a prefix mis-match, quit early
 		if !bytes.Equal(inp, prefix[:i]) {
-			return nil
+			return fmt.Errorf("Invalid Proxy Protocol Header")
 		}
 	}
 


### PR DESCRIPTION
I couldn't really fathom why one would want to simply accept a missing or invalid prefix. In doing so it may lead people to simply enable it everywhere, also on public, non-proxied interfaces. This is a security risk, because a third-party could then fake the source ip by inserting its own proxy protocol line and no one would be none the wiser.

I wanted to make this check optional, not breaking BC and all that, by adding a property to the Listener struct, but I don't see how I could retrieve that in the checkPrefix() function.
