### PR TITLE
Implement io.ReaderFrom/WriterTo for Conn

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -119,6 +119,22 @@ func (p *Conn) Read(b []byte) (int, error) {
 	return p.bufReader.Read(b)
 }
 
+func (p *Conn) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := p.conn.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(p.conn, r)
+}
+
+func (p *Conn) WriteTo(w io.Writer) (int64, error) {
+	var err error
+	p.once.Do(func() { err = p.checkPrefix() })
+	if err != nil {
+		return 0, err
+	}
+	return p.bufReader.WriteTo(w)
+}
+
 func (p *Conn) Write(b []byte) (int, error) {
 	return p.conn.Write(b)
 }


### PR DESCRIPTION
This change increases performance when proxying wrapped connections using io.Copy.
Since go 1.11 copying between tcp connections uses the splice system call on linux yielding considerable performance improvments.
See: https://golang.org/doc/go1.11#net